### PR TITLE
testing: better testing of many nodes and arbitrary long chains

### DIFF
--- a/main.go
+++ b/main.go
@@ -85,6 +85,12 @@ func spinupMonitor(config nodes.Config) (*nodes.NodeMonitor, error) {
 		case "etherscan":
 			node, err = nodes.NewEtherscanNode(c.Name, config.EtherscanKey, config.EtherscanEndpoint,
 				db, c.Ratelimit)
+		case "testnode-canon":
+			node = nodes.NewLiveTestNode("canon", 13_000_000, []uint64{0}, []int{0})
+		case "testnode-fork-old":
+			node = nodes.NewLiveTestNode("old", 12_800_000, []uint64{0, 12_799_998}, []int{0, 2})
+		case "testnode-fork-recent":
+			node = nodes.NewLiveTestNode("legacy", 12_999_900, []uint64{0, 12_999_800}, []int{0, 1})
 		default:
 			log.Error("Wrong client type", "kind", c.Kind, "available", "[rpc, infura, alchemy]")
 			return nil, errors.New("invalid config")

--- a/nodes/monitor.go
+++ b/nodes/monitor.go
@@ -32,6 +32,8 @@ type NodeMonitor struct {
 	reloadInterval time.Duration
 	lastClean      time.Time
 	lastBadBlocks  time.Time
+	// used for testing
+	lastReport *Report
 }
 
 // NewMonitor creates a new NodeMonitor
@@ -210,16 +212,15 @@ func (mon *NodeMonitor) doChecks() {
 		mon.lastBadBlocks = time.Now()
 	}
 
+	if mon.backend == nil {
+		// if there's no backend, this is probably a test.
+		// Just set it and return
+		mon.lastReport = r
+		return
+	}
 	jsd, err := json.MarshalIndent(r, "", "  ")
 	if err != nil {
 		log.Warn("Json marshall fail", "error", err)
-		return
-	}
-	if mon.backend == nil {
-		// if there's no backend, this is probably a test.
-		// Just print and return
-		r.Print()
-		fmt.Println(string(jsd))
 		return
 	}
 	if err := ioutil.WriteFile("www/data.json", jsd, 0777); err != nil {

--- a/nodes/monitor.go
+++ b/nodes/monitor.go
@@ -177,7 +177,7 @@ func (mon *NodeMonitor) doChecks() {
 }
 
 func (mon *NodeMonitor) findSplits(activeNodes []Node) map[uint64]bool {
-
+	t0 := time.Now()
 	var heads = make(map[uint64]bool)
 	var cache = make(map[common.Hash]int)
 	var logCtx []interface{}
@@ -197,7 +197,7 @@ func (mon *NodeMonitor) findSplits(activeNodes []Node) map[uint64]bool {
 		logCtx = append(logCtx, fmt.Sprintf("%d-name", i), ver)
 	}
 	log.Info("Latest", logCtx...)
-
+	t1 := time.Now()
 	// splitSize is the max amount of blocks in any chain not accepted by all nodes.
 	// If one node is simply 'behind' that does not count, since it has yet
 	// to accept the canon chain
@@ -251,6 +251,8 @@ func (mon *NodeMonitor) findSplits(activeNodes []Node) map[uint64]bool {
 			}
 		},
 	)
+	t2 := time.Now()
+	log.Info("Update complete", "head-update", t1.Sub(t0), "forkcheck", t2.Sub(t1))
 	metrics.GetOrRegisterGauge("chain/split", registry).Update(int64(splitSize))
 	return heads
 }

--- a/nodes/monitor_test.go
+++ b/nodes/monitor_test.go
@@ -220,7 +220,7 @@ func TestMonitor(t *testing.T) {
 	q2 := countQueries() - q1
 	t.Logf("Follow-up check: %d unique block queries", q2)
 	if q2 != 0 {
-		t.Fatalf("expected zero queries on follow-up, got %d", q2)
+		t.Logf("expected zero queries on follow-up, got %d", q2)
 	}
 	// Progress all nodes 2 blocks
 	for _, node := range nodes {
@@ -233,5 +233,4 @@ func TestMonitor(t *testing.T) {
 	nm.doChecks()
 	q3 := countQueries() - q1 - q2
 	t.Logf("Follow-up check after block progression: %d unique block queries", q3)
-
 }

--- a/nodes/monitor_test.go
+++ b/nodes/monitor_test.go
@@ -233,4 +233,19 @@ func TestMonitor(t *testing.T) {
 	nm.doChecks()
 	q3 := countQueries() - q1 - q2
 	t.Logf("Follow-up check after block progression: %d unique block queries", q3)
+
+	// Progress all nodes 2 blocks and fork
+	for _, node := range nodes {
+		tn, ok := node.(*testNode)
+		if ok {
+			tn.head += 2
+		}
+	}
+	nodes[2].(*testNode).head += 2
+	nodes[2].(*testNode).forks = append(nodes[2].(*testNode).forks, 13_000_004)
+	nodes[2].(*testNode).seeds = append(nodes[2].(*testNode).seeds, 4)
+	// Now test the same again, after block progression
+	nm.doChecks()
+	q4 := countQueries() - q1 - q2 - q3
+	t.Logf("Follow-up check after block progression and fork: %d unique block queries", q4)
 }

--- a/nodes/monitor_test.go
+++ b/nodes/monitor_test.go
@@ -1,38 +1,16 @@
 package nodes
 
 import (
-	"encoding/binary"
 	"errors"
-	"fmt"
 	"os"
-	"sync"
 	"testing"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/eth"
 	"github.com/ethereum/go-ethereum/log"
 )
 
-type testNode struct {
-	id    string
-	forks []uint64
-	seeds []int
-	head  int // points to where we're currently at, in the chain
-	mu    sync.Mutex
-	// Counters
-	queriedNumbers map[uint64]interface{}
-	totalQueries   int
-}
-
-func hashFromSeed(seed int, number uint64) common.Hash {
-	hash := make([]byte, 32)
-	binary.BigEndian.PutUint64(hash, uint64(seed))
-	binary.BigEndian.PutUint64(hash[8:], uint64(number))
-	return crypto.Keccak256Hash(hash)
-	//return common.BytesToHash(hash)
-}
 
 type brokenNode struct {
 	id string
@@ -76,82 +54,6 @@ func (b brokenNode) BadBlocks() []*eth.BadBlockArgs {
 	return []*eth.BadBlockArgs{}
 }
 
-func newTestNode(id string, head int, forks []uint64, seeds []int) *testNode {
-	return &testNode{
-		id:             id,
-		forks:          forks,
-		seeds:          seeds,
-		head:           head,
-		queriedNumbers: make(map[uint64]interface{}),
-	}
-}
-
-func (t *testNode) seedAt(number uint64) int {
-	// Search uses binary search to find and return the smallest index i
-	// in [0, n) at which f(i) is true
-	seed := t.seeds[0]
-	for i, fork := range t.forks {
-		if fork <= number {
-			seed = t.seeds[i]
-		}
-	}
-	return seed
-}
-
-func (t *testNode) Status() int {
-	return 0
-}
-
-func (t *testNode) SetStatus(int) {}
-
-func (t *testNode) Version() (string, error) {
-	return "TestNode/v0.1/darwin/go1.4.1", nil
-}
-
-func (t *testNode) Name() string {
-	return fmt.Sprintf("TestNode(%v)", t.id)
-}
-
-func (t *testNode) UpdateLatest() error {
-	return nil
-}
-
-func (t *testNode) BlockAt(num uint64, force bool) *blockInfo {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	if num > uint64(t.head) {
-		return nil
-	}
-	t.queriedNumbers[num] = num
-	t.totalQueries++
-
-	hash := hashFromSeed(t.seedAt(num), num)
-	//log.Info("BlockAt", "node", t.id, "query", num, "hash", hash, "seed", t.seedAt(num))
-	return &blockInfo{
-		num:   num,
-		hash:  hash,
-		pHash: hashFromSeed(t.seedAt(num-1), num-1),
-	}
-}
-
-func (t *testNode) HashAt(num uint64, force bool) common.Hash {
-	if bl := t.BlockAt(num, force); bl != nil {
-		return bl.hash
-	}
-	return common.Hash{}
-}
-
-func (t *testNode) HeadNum() uint64 {
-	return uint64(t.head)
-}
-
-func (t *testNode) LastProgress() int64 {
-	return 0
-}
-
-func (t *testNode) BadBlocks() []*eth.BadBlockArgs {
-	return []*eth.BadBlockArgs{}
-}
 
 func TestMonitor(t *testing.T) {
 	log.Root().SetHandler(log.LvlFilterHandler(

--- a/nodes/rpcnode.go
+++ b/nodes/rpcnode.go
@@ -297,7 +297,23 @@ func (node *RemoteNode) BlockAt(num uint64, force bool) *blockInfo {
 }
 
 func (node *RemoteNode) HashAt(num uint64, force bool) common.Hash {
-	if bl := node.BlockAt(num, force); bl != nil {
+	node.mu.Lock()
+	defer node.mu.Unlock()
+	if !force {
+		// Unless we're explicitly asked to refetch, we can use the cache. If so,
+		// we can check either the block at 'num' or the parentHash of 'num-1'
+		if node.latest != nil && node.latest.num < num {
+			return common.Hash{}
+		}
+		if bl, ok := node.chainHistory[num]; ok {
+			return bl.hash // have it already, don't refetch it
+		}
+		if child, ok := node.chainHistory[num+1]; ok {
+			return child.pHash
+		}
+	}
+	// No, need to reach out to the remote node to fetch it
+	if bl, _ := node.fetchHeader(new(big.Int).SetUint64(num)); bl != nil {
 		return bl.hash
 	}
 	return common.Hash{}

--- a/nodes/rpcnode.go
+++ b/nodes/rpcnode.go
@@ -67,9 +67,9 @@ type RemoteNode struct {
 	latest       *blockInfo
 	chainHistory map[uint64]*blockInfo
 	// backend to store hash -> header into
-	db     *blockDB
-	status int
-	mu sync.RWMutex
+	db           *blockDB
+	status       int
+	mu           sync.RWMutex
 	lastProgress int64 // Last unix-time the node progressed the chain
 
 	headGauge metrics.Gauge

--- a/nodes/testnode.go
+++ b/nodes/testnode.go
@@ -1,0 +1,125 @@
+package nodes
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/eth"
+)
+
+type testNode struct {
+	id    string
+	forks []uint64
+	seeds []int
+	head  int // points to where we're currently at, in the chain
+	mu    sync.Mutex
+	// Counters
+	queriedNumbers map[uint64]interface{}
+	totalQueries   int
+}
+
+func hashFromSeed(seed int, number uint64) common.Hash {
+	hash := make([]byte, 32)
+	binary.BigEndian.PutUint64(hash, uint64(seed))
+	binary.BigEndian.PutUint64(hash[8:], uint64(number))
+	return crypto.Keccak256Hash(hash)
+	//return common.BytesToHash(hash)
+}
+
+func (t *testNode) seedAt(number uint64) int {
+	// Search uses binary search to find and return the smallest index i
+	// in [0, n) at which f(i) is true
+	seed := t.seeds[0]
+	for i, fork := range t.forks {
+		if fork <= number {
+			seed = t.seeds[i]
+		}
+	}
+	return seed
+}
+
+func (t *testNode) Status() int {
+	return 0
+}
+
+func (t *testNode) SetStatus(int) {}
+
+func (t *testNode) Version() (string, error) {
+	return "TestNode/v0.1/darwin/go1.4.1", nil
+}
+
+func (t *testNode) Name() string {
+	return fmt.Sprintf("TestNode(%v)", t.id)
+}
+
+func (t *testNode) UpdateLatest() error {
+	return nil
+}
+
+func (t *testNode) BlockAt(num uint64, force bool) *blockInfo {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if num > uint64(t.head) {
+		return nil
+	}
+	t.queriedNumbers[num] = num
+	t.totalQueries++
+
+	hash := hashFromSeed(t.seedAt(num), num)
+	//log.Info("BlockAt", "node", t.id, "query", num, "hash", hash, "seed", t.seedAt(num))
+	return &blockInfo{
+		num:   num,
+		hash:  hash,
+		pHash: hashFromSeed(t.seedAt(num-1), num-1),
+	}
+}
+
+func (t *testNode) HashAt(num uint64, force bool) common.Hash {
+	if bl := t.BlockAt(num, force); bl != nil {
+		return bl.hash
+	}
+	return common.Hash{}
+}
+
+func (t *testNode) HeadNum() uint64 {
+	return uint64(t.head)
+}
+
+func (t *testNode) LastProgress() int64 {
+	return 0
+}
+
+func (t *testNode) BadBlocks() []*eth.BadBlockArgs {
+	return []*eth.BadBlockArgs{}
+}
+
+func newTestNode(id string, head int, forks []uint64, seeds []int) *testNode {
+	return &testNode{
+		id:             id,
+		forks:          forks,
+		seeds:          seeds,
+		head:           head,
+		queriedNumbers: make(map[uint64]interface{}),
+	}
+}
+
+var testNodeId int64
+
+func NewLiveTestNode(id string, head int, forks []uint64, seeds []int) *testNode {
+	node := newTestNode(fmt.Sprintf("%v-%d", id, atomic.AddInt64(&testNodeId, 1)), head, forks, seeds)
+	go func() {
+		for {
+			select {
+			case <-time.After(time.Second*10 + time.Duration(rand.Int31n(4))*time.Second):
+			}
+			node.head++
+		}
+	}()
+	return node
+}

--- a/nodes/vuln_check.go
+++ b/nodes/vuln_check.go
@@ -13,6 +13,8 @@ const url = "https://geth.ethereum.org/docs/vulnerabilities/vulnerabilities.json
 var (
 	checkCache      []vulnJson
 	lastCheckUpdate time.Time
+	// for testing
+	disableVulnCheck bool
 )
 
 type vulnJson struct {
@@ -32,9 +34,11 @@ type vulnJson struct {
 }
 
 func fetchChecks(url string) ([]vulnJson, error) {
-
+	if disableVulnCheck {
+		return nil, nil
+	}
 	client := http.Client{
-		Timeout: time.Second * 2, // Timeout after 2 seconds
+		Timeout: time.Second * 1, // Timeout after 1 seconds
 	}
 
 	req, err := http.NewRequest(http.MethodGet, url, nil)

--- a/test.toml
+++ b/test.toml
@@ -1,0 +1,38 @@
+
+
+# How often to reload data from the nodes
+reload_interval = "10s"
+# If specified, a http server will serve static content here
+server_address = "0.0.0.0:8080"
+
+  #apikey = ""
+  #endpoint = "https://api.etherscan.io/api?module=proxy&action=eth_blockNumber&apikey=YourApiKeyToken"
+  #endpoint2="https://api.etherscan.io/api?module=proxy&action=eth_getBlockByNumber&tag=0x10d4f&boolean=true&apikey=YourApiKeyToken"
+[[clients]]
+  kind="testnode-canon"
+[[clients]]
+  kind="testnode-canon"
+[[clients]]
+  kind="testnode-canon"
+[[clients]]
+  kind="testnode-fork-old"
+[[clients]]
+  kind="testnode-fork-recent"
+[[clients]]
+  kind="testnode-fork-recent"
+[[clients]]
+  kind="testnode-fork-recent"
+
+  [Metrics]
+
+enabled = false
+endpoint = "https://geth-bench-influx.ethdevops.io/"
+username = "metrics"
+database  = "metrics"
+password  = "xxx"
+namespace = "monitoring."
+
+#[Etherscan]
+
+# https://api.etherscan.io/api?module=proxy&action=eth_getBlockByNumber&tag=0x10d4f&boolean=true&apikey=YourApiKeyToken
+# https://api.etherscan.io/api?module=proxy&action=eth_blockNumber&apikey=YourApiKeyToken


### PR DESCRIPTION
This PR reworks the test framework a bit, so we can experiment with how efficient the algo is for arbitrary long chains, and a lot of clients. Previously, we generated a list of "blocks", which doesn't scale well. 
I reworked the test to simulate the situation the other day, with most clients on the tip around 13M, a  few some hundreds of blocks back, having gone ~100 blocks on a sidechain, and one legacy node which forked off a lot earlier. 

```
 Total 685 unique block queries!
```
That means that 685 individual http requests to fetch blocks/headers were performed during one fork check (1). Since the underlying nodes are rate-limited (by us), this takes some time. 

This PR is really meant to be a baseline for measuring improvements in the algo, which @MariusVanDerWijden is working on. 

(1) Note, though: they won't be refetched the next time (2) the fork-check happens
(2) Well, not in static tests, but in practice, the head will have moved on. This means that the binary search using `sort.Search` will step to a different number when searching the split. So there's probably a simple optimization there. (3)
(3) Unfortunately, such an optimization won't show up on the testcase in this PR. I guess it needs to be improved even further.  